### PR TITLE
fix: build container runner with panflute>=2.3.1 for Pandoc3 Typst AST support

### DIFF
--- a/.github/runners/Dockerfile.quarto-doc-builder
+++ b/.github/runners/Dockerfile.quarto-doc-builder
@@ -55,7 +55,7 @@ RUN arch=$(dpkg --print-architecture) && \
 #                 files.upload(file=), see gemini_client.py)
 # tiktoken     -> token counting for the LLM rate limiter
 RUN pip install --no-cache-dir --break-system-packages \
-    panflute PyYAML google-genai==2.6.0 tiktoken==0.13.0 && \
+    panflute>=2.3.1 PyYAML google-genai==2.6.0 tiktoken==0.13.0 && \
     python3 -m pip cache purge 2>/dev/null || true && \
     rm -rf /root/.cache /tmp/* /var/tmp/*
 


### PR DESCRIPTION
The rendering pipeline currently fails with a TypeError during Quarto AST parsing of Typst blocks because the container uses an older panflute package (<2.3.0) that has a hardcoded whitelist of allowed output formats missing . Updating to  resolves this compilation compatibility blocker.