### PR TITLE
feat: support reports category in main build script

### DIFF
--- a/.github/scripts/build/group_docs_by_category.py
+++ b/.github/scripts/build/group_docs_by_category.py
@@ -18,6 +18,7 @@ EXCLUDED_DOCS_DIRS = {
 CATEGORY_TO_DIRECTORY_MAP = {
     "guidelines": "guidelines",
     "products": "products",
+    "reports": "reports",
 }
 
 


### PR DESCRIPTION
This PR updates the CATEGORY_TO_DIRECTORY_MAP sitemap dictionary inside the main python categorizer (group_docs_by_category.py). 

This allows reports to compile cleanly under our new `/reports/` sitemap target folder without throwing compilation omissions or getting ignored by Quarto.

Configured targets:
-   `"reports": "reports"` mapped.