### PR TITLE
Align YAML header convention across templates, editor-manual, and DOCS/

### DIFF
--- a/DOCS/High_Resolution_Layer/Small_Landscape_Features_2021_PUM_v1.qmd
+++ b/DOCS/High_Resolution_Layer/Small_Landscape_Features_2021_PUM_v1.qmd
@@ -1,8 +1,14 @@
 ---
+title: "High Resolution Layer Small Landscape Features 2021 – Product User Manual"
+subtitle: "Copernicus Land Monitoring Service"
+date: '2025-09-16'
+version: 1.0
+
 category: products
-date: 2025-09-16
-subtitle: Copernicus Land Monitoring Service
-title: High Resolution Layer Small Landscape Features 2021 – Product User Manual
+
+toc: true
+toc-title: "Content"
+toc-depth: 3
 ---
 
 # Non-technical summary {#sec-non-technical-summary}

--- a/DOCS/guidelines/editor-manual_v1.qmd
+++ b/DOCS/guidelines/editor-manual_v1.qmd
@@ -68,34 +68,44 @@ Migrating an existing `.docx`? See the Migration Guide [TBD link].
 
 # The YAML Header
 
-If you copied a template, the header is pre-filled - just update `title`, `subtitle`, `date`, and `product-name`.
+If you copied a template, the header is pre-filled — update `title`, `subtitle`, `date`, `category`, and `version`.
 
 ## Required fields
 
 ```yaml
 ---
-title: "HRL Forest"
-subtitle: "High Resolution Layer - Forest Type"
-date: "2026-01-27"
-product-name: "HRL Forest"
+category: products
+date: '2026-01-27'
+subtitle: Copernicus Land Monitoring Service
+title: HRL Forest - Product User Manual
+toc: true
+toc-depth: 3
+toc-title: Content
+version: 1.0
 ---
 ```
 
-- `title` - short product name, appears as the document title
-- `subtitle` - full product name or document type description
-- `date` - publication or last-updated date in ISO format
-- `product-name` - used internally for metadata and indexing
+- `category` — one of `products`, `guidelines`, or `non-browsable`. Determines where the document appears in the library.
+- `date` — publication or last-updated date in ISO format (`YYYY-MM-DD`).
+- `subtitle` — typically `Copernicus Land Monitoring Service` for product documents.
+- `title` — the document title, including the product name and document type (e.g. "– Product User Manual").
+- `toc` — always `true` for published documents.
+- `toc-depth` — always `3`.
+- `toc-title` — always `Content`.
+- `version` — the current published version (e.g. `1.0`, `2.3`). This number appears in the document header and must match the filename suffix.
 
 ## Optional fields
 
-- `template-version` - records which template version was used as the starting point. Set automatically when copying a template; don't edit it manually.
+- `author` — document author or organisation (e.g. `Copernicus Land Monitoring Service`).
+- `description` — a short summary of the document, used for SEO and library listings.
+- `editor` — Quarto editor settings (e.g. `markdown: wrap: 72`).
+- `template-version` — records which template version was used as the starting point. Set automatically when copying a template; don't edit it manually.
 
 ## System-managed fields
 
-Leave these out of your YAML header entirely - the publishing system handles them:
+Leave these out of your YAML header entirely — the publishing system handles them:
 
-- `keywords` - AI-generated at publish time based on document content. Anything you add gets overwritten.
-- `version` - carried by the filename suffix, not the YAML. No version field belongs in the header.
+- `keywords` — AI-generated at publish time based on document content. Anything you add gets overwritten.
 
 
 # Writing Content
@@ -225,7 +235,7 @@ Your work lives in `DOCS/` directly: one `.qmd` file per document, plus a matchi
 
 ## The version suffix
 
-The `_v<N>` suffix in the filename is the major version - the only version number you control. Minor and patch versions are assigned automatically by AI at library release time based on the scope of changes: small corrections get a patch bump (`2.3.5 → 2.3.6`), new or revised sections get a minor bump (`2.3.0 → 2.4.0`). A new file `CLMS_HRL-Forest_PUM_v3.qmd` starts at `3.0.0` at its first release. You never set a version number in YAML.
+The `_v<N>` suffix in the filename and the `version` field in the YAML header should match — both carry the major version. Minor and patch versions are assigned automatically by AI at library release time based on the scope of changes: small corrections get a patch bump (`2.3.5 → 2.3.6`), new or revised sections get a minor bump (`2.3.0 → 2.4.0`). A new file `CLMS_HRL-Forest_PUM_v3.qmd` starts with `version: 3.0` in YAML and `3.0.0` at its first release.
 
 ## When to create a new major version
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,20 @@ This repository is designed to be fully customizable. If you wish to fork this p
 ### 1. Structure Your Documents
 1. Clean your repository structure and place your Markdown (`.qmd`) document files under `DOCS/`.
 2. Give your files a version-controlling suffix (e.g., `My_Manual_v1.qmd`).
-3. Set your document metadata categories by adding headers at the top of your `.qmd` files:
+3. Set your document metadata by adding a YAML header at the top of each `.qmd` file:
    ```yaml
    ---
-   title: "Technical Specification"
-   category: "products" # can be products, guidelines, or non-browsable
+   category: products
+   date: '2025-01-15'
+   subtitle: Your Organization Name
+   title: Technical Specification – Product User Manual
+   toc: true
+   toc-depth: 3
+   toc-title: Content
+   version: 1.0
    ---
    ```
+   `category` can be `products`, `guidelines`, or `non-browsable`.
 
 ### 2. Configure Your Brand Assets
 *   Go to `assets/` and replace the logo files (`copernicus-logo.svg`, `lms_logo.svg`) with your own organization logos.

--- a/_meta/templates/CLMS_ATBD_Template.qmd
+++ b/_meta/templates/CLMS_ATBD_Template.qmd
@@ -1,12 +1,14 @@
 ---
-title: "Product SHORT NAME ALGORITHM THEORETICAL BASIS DOCUMENT (ATBD)"
-subtitle: "ATBD Copernicus Land Monitoring Service -- Product full name"
-date: "2022-10-06"
-version: Issue x.y (“(x) version of the document” + “.”+ “(y) version  of the document
-  update”)
+category: products
+date: '2022-10-06'
+subtitle: Copernicus Land Monitoring Service
+title: Product short name – Algorithm Theoretical Basis Document (ATBD)
+toc: true
+toc-depth: 3
+toc-title: Content
+version: 1.0
 template-version: 1.0.0
-product-name: Product Name
-description: "Product DESCRIPTION"
+description: Product DESCRIPTION
 
 format:
   html:

--- a/_meta/templates/CLMS_PUM_Template.qmd
+++ b/_meta/templates/CLMS_PUM_Template.qmd
@@ -1,12 +1,14 @@
 ---
-title: "Product full name – Product User Manual (PUM)"
-subtitle: "Copernicus Land Monitoring Service"
-date: "2022-10-06"
-version: Issue x.y (“(x) version of the document” + “.”+ “(y) version of the document
-  update”) (first published version must start with 1.0)
+category: products
+date: '2022-10-06'
+subtitle: Copernicus Land Monitoring Service
+title: Product full name – Product User Manual (PUM)
+toc: true
+toc-depth: 3
+toc-title: Content
+version: 1.0
 template-version: 1.0.0
-product-name: Product Name
-description: "Product DESCRIPTION"
+description: Product DESCRIPTION
 
 format:
   html:


### PR DESCRIPTION
## Problem

The YAML header convention was inconsistent across three sources:

- **Templates** (`_meta/templates/`) used double quotes, `product-name`, a `format:` block, placeholder `version` text
- **Editor-manual** forbade `version` in YAML, required `product-name`, omitted `category`/`toc`/`toc-depth`/`toc-title`
- **Actual DOCS/ on main** use no quotes, `category` first, `toc` group, `version` present

## Changes

### `editor-manual_v1.qmd`
- YAML example updated to match actual convention
- `version` moved from forbidden to required
- `category`, `toc`, `toc-depth`, `toc-title` documented
- `product-name` removed
- Contradictory versioning paragraph fixed

### Templates (PUM + ATBD)
- Stripped double quotes, added `category`/`toc`/`version`, removed `product-name`

### `Small_Landscape_Features_2021_PUM_v1.qmd`
- Fixed date from `DD/MM/YYYY` to ISO format to pass frontmatter validation

No other DOCS/ content files touched.