### PR TITLE
fix: hide OJS code blocks in dashboard

### DIFF
--- a/DOCS/CDSE_Migration/CLMS_CDSE_Migration_Dashboard.qmd
+++ b/DOCS/CDSE_Migration/CLMS_CDSE_Migration_Dashboard.qmd
@@ -4,12 +4,12 @@ subtitle: "Weekly Status Update"
 author: "Copernicus Land Monitoring Service"
 date: 2026-07-16
 category: non-browsable
+echo: false
 format:
   html:
     page-layout: full
     toc: true
     toc-depth: 2
-    echo: false
     embed-resources: false
 ---
 


### PR DESCRIPTION
Moves  from  to document-level frontmatter. OJS code cells were rendering as visible code blocks despite the HTML-level setting.