### PR TITLE
docs: fix grammar in migration status table sentence

### DIFF
--- a/DOCS/CDSE_Migration/CLMS_CDSE_Migration_Dashboard.qmd
+++ b/DOCS/CDSE_Migration/CLMS_CDSE_Migration_Dashboard.qmd
@@ -277,7 +277,7 @@ ${(odataWeeklyDelta || odataDailyDelta || odataHist.length > 0) ? htl.html `
 
 ## CLMS Product on CDSE
 
-This table shows the full CLMS portfolio with their migration status to the CDSE.
+This table shows the full, currently active CLMS portfolio and each product's migration status to the CDSE.
 ```{ojs}
 // Toggle-button style filter: click a component to enable/disable it
 // (multi-select, all enabled by default). Replaces the old single-select
@@ -488,6 +488,12 @@ productGroupsTable = {
 
 ```
 
+## On CDSE soon
+
+> _Details to be provided — placeholder for upcoming CLMS products planned for CDSE ingestion._
+
+Preparing dataset descriptions, expected timelines, and service coverage for the next batch of products to be onboarded.
+
 ## Services
 
 - [S3 CSV Catalogue](https://csv.dataspace.copernicus.eu/CLMS/)
@@ -496,14 +502,6 @@ productGroupsTable = {
 - [OpenEO](https://openeo.dataspace.copernicus.eu/)
 - [Sentinel Hub](https://documentation.dataspace.copernicus.eu/APIs/SentinelHub/Data/CLMS.html)
 - [CDSE Documentation](https://documentation.dataspace.copernicus.eu/Data/CopernicusServices/CLMS.html)
-
-## On CDSE soon
-
-> _Details to be provided — placeholder for upcoming CLMS products planned for CDSE ingestion._
-
-Preparing dataset descriptions, expected timelines, and service coverage for the next batch of products to be onboarded.
-
----
 
 ## Methodology
 


### PR DESCRIPTION
Fix pronoun agreement: 'their' → 'the full, currently active CLMS portfolio and each product's migration status'.