### PR TITLE
fix: rename RELEASE to REVISION in filenaming docs

### DIFF
--- a/DOCS/filenaming/clms-filename-tree_v1.qmd
+++ b/DOCS/filenaming/clms-filename-tree_v1.qmd
@@ -13,7 +13,7 @@ title: CLMS Filename Tree
 ---
 
 ```
-CLMS_{CODE}-{VARIABLE}[-{SUBVARIABLE}]_{TEMPORAL}_{RES}_{EXTENT}_{EPSG}_{VERSION}-{RELEASE}.ext
+CLMS_{CODE}-{VARIABLE}[-{SUBVARIABLE}]_{TEMPORAL}_{RES}_{EXTENT}_{EPSG}_{VERSION}-{REVISION}.ext
 ```
 
 ## By Product Code
@@ -192,13 +192,13 @@ CLMS_
      │       └── R20m_                raster 20m
      │           └── T38TKL_          MGRS tile
      │               └── 3035_        EPSG 3035
-     │                   └── V01-R00.tif  version 1, release 0
+     │                   └── V01-R00.tif  version 1, revision 0
      │
      └── EGMS-L2a-A_                  European Ground Motion — L2a ascending
          └── T20190101P5Y_            5-year timeseries
              └── R20-5m_              irregular grid 20x5m
                  └── 054-0154-IW1_    IW burst
-                     └── V01-R00.tif  version 1, release 0
+                     └── V01-R00.tif  version 1, revision 0
 ```
 
 ---

--- a/DOCS/filenaming/clms-filenaming-design-principles_v1.qmd
+++ b/DOCS/filenaming/clms-filenaming-design-principles_v1.qmd
@@ -75,7 +75,7 @@ The period `.` (ASCII 46) is reserved exclusively for the file extension separat
 
 ## Principle 4 — Delimiter: Underscore `_` between fields, hyphen `-` within fields
 
-**Rule:** Use `_` to separate all top-level fields. The hyphen `-` is the **within-field separator**: it joins the variable (and sub-variables) to the product code (`VLCC-GRA`, `WSI-SP-SCD`), joins version to release (`V01-R00`), and appears where a notation itself requires it (e.g., `054-0154-IW1` for IW burst tile identifiers, `C2018-2021` for change periods). It is never a cross-field delimiter.
+**Rule:** Use `_` to separate all top-level fields. The hyphen `-` is the **within-field separator**: it joins the variable (and sub-variables) to the product code (`VLCC-GRA`, `WSI-SP-SCD`), joins version to revision (`V01-R00`), and appears where a notation itself requires it (e.g., `054-0154-IW1` for IW burst tile identifiers, `C2018-2021` for change periods). It is never a cross-field delimiter.
 
 **Rationale:** Consistent underscore delimiters make tokenisation deterministic across all product families. The hyphen carries all intra-field structure, so splitting on `_` always yields the same field count within a product family.
 
@@ -96,7 +96,7 @@ The period `.` (ASCII 46) is reserved exclusively for the file extension separat
 > **Canonical template:**
 >
 > ```
-> CLMS_{CODE}-{VARIABLE}[-{SUBVARIABLE}]_{TEMPORAL}_{RES}_{EXTENT}_{EPSG}_{VERSION}-{RELEASE}
+> CLMS_{CODE}-{VARIABLE}[-{SUBVARIABLE}]_{TEMPORAL}_{RES}_{EXTENT}_{EPSG}_{VERSION}-{REVISION}
 > ```
 
 Sub-products within a family (e.g., SP, SWS, WDS within WSI) extend the compound with a further hyphen (`WSI-SP-SCD`, `WSI-WDS-SSC`). This keeps the underscore token count identical for every file in the family.
@@ -232,7 +232,7 @@ Spatial extent identifiers are `_`-separated from adjacent tokens. Never fuse th
 
 ## Principle 12 — Version: `V{XX}-R{YY}` single hyphenated field
 
-**Rule:** A single compound token: `V{XX}` (major, 2-digit zero-padded), hyphen, `R{YY}` (release, 2-digit zero-padded). Never use packed `V{XXX}`.
+**Rule:** A single compound token: `V{XX}` (major, 2-digit zero-padded), hyphen, `R{YY}` (revision, 2-digit zero-padded). Never use packed `V{XXX}`.
 
 **Compliant:** `V01-R00`, `V01-R01`, `V02-R00`
 
@@ -328,7 +328,7 @@ Some aspects genuinely differ between product families and should not be forced 
 | 1  | Filename structure  | Fields separated by `_`, stem.extension                                                                                   |
 | 2  | Allowed characters  | `A–Z`, `0–9`, `_`, `-` only; no lowercase, no spaces                                                                      |
 | 3  | Max filename length | ≤255 chars stem+extension, recommend ≤100                                                                                 |
-| 4  | Delimiter           | `_` between fields; `-` within fields (code-variable compound, version-release, notations)                                |
+| 4  | Delimiter           | `_` between fields; `-` within fields (code-variable compound, version-revision, notations)                                |
 | 5  | Field order         | Variable hyphen-appended to product code at position 2; canonical template defines field sequence                         |
 | 6  | Prefix              | `CLMS_` mandatory for all products, no exceptions                                                                         |
 | 7  | Product code        | Short, uppercase, registered in code registry                                                                             |


### PR DESCRIPTION
The merged PR #59 used `{VERSION}-{RELEASE}`; the correct term is `REVISION`.\n\nChanges:\n- Canonical template: `{VERSION}-{REVISION}`\n- P12: `R{YY}` is **revision** (2-digit zero-padded)\n- All examples and descriptions updated accordingly\n\nSource .md files in ncshare already updated; this brings the qmd docs into alignment.