### PR TITLE
fix: update deprecated gemini-2.5-flash to gemini-2.5-flash-001

### DIFF
--- a/.github/scripts/helpers/gemini_client.py
+++ b/.github/scripts/helpers/gemini_client.py
@@ -32,7 +32,7 @@ def get_client() -> "genai.Client":
 # ---------------------------------------------------------------------------
 # Model & rate-limit constants  (Gemini 2.5 Flash – tier 1)
 # ---------------------------------------------------------------------------
-MODEL_NAME = "gemini-2.5-flash"
+MODEL_NAME = "gemini-2.5-flash-001"
 
 RPM_LIMIT = 995  # Requests per minute
 TPM_LIMIT = 750_000  # Tokens per minute


### PR DESCRIPTION
Google deprecated `gemini-2.5-flash` for new users. The CI build fails on main with:\n\n> 404 NOT_FOUND — This model is no longer available to new users\n\nUpdated to `gemini-2.5-flash-001` in `.github/scripts/helpers/gemini_client.py`.\n\nThis will unblock the deploy pipeline so the MRVPP documents (PR #68) get published.