### PR TITLE
fix: use gemini-2.5-flash-latest

### DIFF
--- a/.github/scripts/helpers/gemini_client.py
+++ b/.github/scripts/helpers/gemini_client.py
@@ -32,7 +32,7 @@ def get_client() -> "genai.Client":
 # ---------------------------------------------------------------------------
 # Model & rate-limit constants  (Gemini 2.5 Flash – tier 1)
 # ---------------------------------------------------------------------------
-MODEL_NAME = "gemini-2.5-flash-001"
+MODEL_NAME = "gemini-2.5-flash-latest"
 
 RPM_LIMIT = 995  # Requests per minute
 TPM_LIMIT = 750_000  # Tokens per minute


### PR DESCRIPTION
Previous attempt with `gemini-2.5-flash-001` also failed (not found in v1beta API). Trying `gemini-2.5-flash-latest` which should resolve to the current stable version.