### PR TITLE
fix: use gemini-2.0-flash (GA)

### DIFF
--- a/.github/scripts/helpers/gemini_client.py
+++ b/.github/scripts/helpers/gemini_client.py
@@ -30,9 +30,9 @@ def get_client() -> "genai.Client":
 
 
 # ---------------------------------------------------------------------------
-# Model & rate-limit constants  (Gemini 2.5 Flash – tier 1)
+# Model & rate-limit constants  (Gemini 2.0 Flash – tier 1)
 # ---------------------------------------------------------------------------
-MODEL_NAME = "gemini-2.5-flash-latest"
+MODEL_NAME = "gemini-2.0-flash"
 
 RPM_LIMIT = 995  # Requests per minute
 TPM_LIMIT = 750_000  # Tokens per minute


### PR DESCRIPTION
## Why not 2.5 Flash

Google has restricted `gemini-2.5-flash` to existing users only. The CI's API key is too new to access it. The `-001` suffix is a Vertex AI naming convention, not valid in the GenAI v1beta API.

`gemini-2.0-flash` is GA (General Availability) and open to all API keys — this is the correct fix.