### PR TITLE
docs: unify CLMS filenaming doc names and title pattern

### DIFF
--- a/DOCS/filenaming/clms-filenaming_design-principles_v1.qmd
+++ b/DOCS/filenaming/clms-filenaming_design-principles_v1.qmd
@@ -3,10 +3,10 @@ author: European Environment Agency (EEA)
 category: guidelines
 date: '2026-07-24'
 subtitle: Copernicus Land Monitoring Service - Technical Library
-title: CLMS Product Filenaming — Design Principles
+title: CLMS Product Filenaming - Design Principles
 ---
 
-# CLMS Product Filenaming — Design Principles
+# CLMS Product Filenaming - Design Principles
 
 *Grounded in the parsEO schema registry, CDSE product catalogue, and current filenaming conventions.*
 
@@ -14,11 +14,11 @@ title: CLMS Product Filenaming — Design Principles
 
 ## Purpose and Scope
 
-These principles govern the filenaming of **all new CLMS product deliveries** — new products, reprocessings, and new versions of existing products. They describe the target convention; existing files on CDSE under legacy names remain as-is but are non-compliant.
+These principles govern the filenaming of **all new CLMS product deliveries** - new products, reprocessings, and new versions of existing products. They describe the target convention; existing files on CDSE under legacy names remain as-is but are non-compliant.
 
 ---
 
-## Principle 1 — Filename Structure: fields, delimiter, extension
+## Principle 1 - Filename Structure: fields, delimiter, extension
 
 **Rule:** A CLMS filename consists of a stem (base name) and if required (e.g. not folder names) an extension, separated by a period `.`:
 
@@ -26,7 +26,7 @@ These principles govern the filenaming of **all new CLMS product deliveries** �
 {stem}.{extension}
 ```
 
-The stem is composed of **fields** — descriptive elements separated by underscore `_`. Each field carries a specific meaning:
+The stem is composed of **fields** - descriptive elements separated by underscore `_`. Each field carries a specific meaning:
 
 ```
 field1_field2_field3_…_fieldN.ext
@@ -42,7 +42,7 @@ Fields may not be empty. A field delimiter may not appear at the beginning or en
 
 ---
 
-## Principle 2 — Allowed Characters: uppercase, digits, underscore, hyphen
+## Principle 2 - Allowed Characters: uppercase, digits, underscore, hyphen
 
 **Rule:** Filenames MUST use only the following ASCII characters:
 
@@ -63,7 +63,7 @@ The period `.` (ASCII 46) is reserved exclusively for the file extension separat
 
 ---
 
-## Principle 3 — Maximum Filename Length
+## Principle 3 - Maximum Filename Length
 
 **Rule:** The complete filename (stem + extension) MUST NOT exceed 255 characters. The fully qualified file name (including path) SHOULD NOT exceed 260 characters.
 
@@ -73,7 +73,7 @@ The period `.` (ASCII 46) is reserved exclusively for the file extension separat
 
 ---
 
-## Principle 4 — Delimiter: Underscore `_` between fields, hyphen `-` within fields
+## Principle 4 - Delimiter: Underscore `_` between fields, hyphen `-` within fields
 
 **Rule:** Use `_` to separate all top-level fields. The hyphen `-` is the **within-field separator**: it joins the variable (and sub-variables) to the product code (`VLCC-GRA`, `WSI-SP-SCD`), joins version to revision (`V01-R00`), and appears where a notation itself requires it (e.g., `054-0154-IW1` for IW burst tile identifiers, `C2018-2021` for change periods). It is never a cross-field delimiter.
 
@@ -89,9 +89,9 @@ The period `.` (ASCII 46) is reserved exclusively for the file extension separat
 
 ---
 
-## Principle 5 — Field Order: Variable hyphen-appended to the product code, token count invariant
+## Principle 5 - Field Order: Variable hyphen-appended to the product code, token count invariant
 
-**Rule:** Fields appear in a fixed order per product family. The variable is **not a standalone field**: it is hyphen-appended to the product code in position 2 (`{CODE}-{VARIABLE}[-{SUBVARIABLE}]`). Underscore-separated token count is invariant across a product family — a sub-product identifier is never a separate positional field; it is encoded within the code-variable compound:
+**Rule:** Fields appear in a fixed order per product family. The variable is **not a standalone field**: it is hyphen-appended to the product code in position 2 (`{CODE}-{VARIABLE}[-{SUBVARIABLE}]`). Underscore-separated token count is invariant across a product family - a sub-product identifier is never a separate positional field; it is encoded within the code-variable compound:
 
 > **Canonical template:**
 >
@@ -101,7 +101,7 @@ The period `.` (ASCII 46) is reserved exclusively for the file extension separat
 
 Sub-products within a family (e.g., SP, SWS, WDS within WSI) extend the compound with a further hyphen (`WSI-SP-SCD`, `WSI-WDS-SSC`). This keeps the underscore token count identical for every file in the family.
 
-**Rationale:** Code and variable together identify **what** the file is; the remaining fields identify **when**, **where**, and **which version**. Placing the full product identity at position 2 groups all files of a product and its layers together in directory listings, and a parser always knows which position holds which field — no branching logic based on which sub-product happens to be present.
+**Rationale:** Code and variable together identify **what** the file is; the remaining fields identify **when**, **where**, and **which version**. Placing the full product identity at position 2 groups all files of a product and its layers together in directory listings, and a parser always knows which position holds which field - no branching logic based on which sub-product happens to be present.
 
 **Compliant:**
 
@@ -111,7 +111,7 @@ Sub-products within a family (e.g., SP, SWS, WDS within WSI) extend the compound
 
 ---
 
-## Principle 6 — Programme Prefix: `CLMS_` mandatory, no exceptions
+## Principle 6 - Programme Prefix: `CLMS_` mandatory, no exceptions
 
 **Rule:** Every CLMS product filename MUST begin with `CLMS_`. No exceptions. No product is exempt. This applies to all new deliveries, reprocessings, and new product versions across the entire CLMS portfolio (EEA, JRC, contractors).
 
@@ -128,7 +128,7 @@ Sub-products within a family (e.g., SP, SWS, WDS within WSI) extend the compound
 
 ---
 
-## Principle 7 — Product Code: Short, uppercase, registered
+## Principle 7 - Product Code: Short, uppercase, registered
 
 **Rule:** Product codes must be registered in the CLMS product code registry before schema authoring. Uppercase alphanumeric only. Prefer 4–7 characters. Retain the `HR` prefix only when it is part of the established acronym.
 
@@ -138,20 +138,20 @@ Sub-products within a family (e.g., SP, SWS, WDS within WSI) extend the compound
 
 ---
 
-## Principle 8 — Temporal Coverage: Format matches product type
+## Principle 8 - Temporal Coverage: Format matches product type
 
 **Rule:**
 
 | Situation       | Format                   | Examples                                        | Definition                                                                                                                                                                                                                                                                                   |
 |-----------------|--------------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Sensing instant | `{YYYYMMDD}T{HHMMSS}`    | `20210217T053159`                               | Single acquisition at a specific date+time (e.g. satellite scene). Zero-duration temporal instant. Uses bare ISO 8601 `dateTime` lexical form — the `T` separator and fixed-width format make it self-identifying, so no semantic prefix is needed.                                          |
+| Sensing instant | `{YYYYMMDD}T{HHMMSS}`    | `20210217T053159`                               | Single acquisition at a specific date+time (e.g. satellite scene). Zero-duration temporal instant. Uses bare ISO 8601 `dateTime` lexical form - the `T` separator and fixed-width format make it self-identifying, so no semantic prefix is needed.                                          |
 | Aggregated      | `A{YYYYMMDD}P{duration}` | `A20240101P10D`, `A20240101P1M`, `A20240101P1Y` | A 2D snapshot where pixel values are derived by **compositing, averaging, or selecting** from multiple observations over time using a defined algorithm. The temporal dimension is **collapsed** to a single representative value per pixel; the file is not designed for temporal querying. |
 | Status          | `S{YYYY}`                | `S2021`                                         | A static thematic map or interpreted classification representing a single reference year. The product does **not** represent a statistical aggregate of repeated measurements; it is the result of a single survey, interpretation, or classification exercise.                              |
 | Change          | `C{YYYY}-{YYYY}`         | `C2018-2021`                                    | A map of transitions or differences between two Status reference years. The two years are the start and end of the change period. The output is a 2D change layer (not a time-series stack).                                                                                                 |
 | Timeseries      | `T{YYYYMMDD}P{duration}` | `T20190101P5Y`                                  | A single file containing **preserved multi-temporal measurements** where the temporal dimension is queryable (e.g. as internal bands, layers, or a time-enabled data cube). Designed for temporal analysis, not as a collapsed 2D snapshot.                                                  |
 | Forecast        | `F{YYYYMMDD}P{duration}` | *(Reserved)*                                    | **Reserved/Proposed.** For future forecast/modelled products. Not currently in use.                                                                                                                                                                                                          |
 
-**Temporal reference standard:** All temporal formats follow **ISO 8601-1:2019** (Date and time — Representations for information interchange). The `P{duration}` suffix uses the ISO 8601 duration format (`P10D`, `P1M`, `P1Y`). Reference: https://www.iso.org/standard/70907.html
+**Temporal reference standard:** All temporal formats follow **ISO 8601-1:2019** (Date and time - Representations for information interchange). The `P{duration}` suffix uses the ISO 8601 duration format (`P10D`, `P1M`, `P1Y`). Reference: https://www.iso.org/standard/70907.html
 
 **Edge case:** Multi-seasonal products encode the season in the code-variable compound (`-S1`, `-S2`), not in the temporal field. This is consistent with external standards (CF Conventions, NASA EOSDIS) which treat season as a data attribute, not a temporal primitive.
 
@@ -165,16 +165,16 @@ Sub-products within a family (e.g., SP, SWS, WDS within WSI) extend the compound
 
 ---
 
-## Principle 9 — Resolution: `R{value}[unit]` for raster, `V{value}[unit]` for vector and point grid
+## Principle 9 - Resolution: `R{value}[unit]` for raster, `V{value}[unit]` for vector and point grid
 
 **Rule:** Raster and gridded products use `R{value}[unit]` with no zero-padding: `R10m`, `R1km`, `R100m`. The value is the integer pixel/grid spacing in metres. Irregular grid spacings join both values with a hyphen within the field: `R20-5m` (e.g., EGMS L2 20×5 m posting).
 
 The `V` prefix covers two cases:
 
-- **Vector minimum mapping units** — `V{value}ha` (e.g., `V025ha` for Urban Atlas 0.25 ha, `V25ha` for CLC 25 ha). Sub-1 ha values use a leading zero with no decimal point.
-- **Point grid posting spacing** — `V{value}m` for regular grids (e.g., `V100m` for EGMS L3) or `V{value}-{value}m` for irregular grids (e.g., `V20-5m` for EGMS L2 point data)
+- **Vector minimum mapping units** - `V{value}ha` (e.g., `V025ha` for Urban Atlas 0.25 ha, `V25ha` for CLC 25 ha). Sub-1 ha values use a leading zero with no decimal point.
+- **Point grid posting spacing** - `V{value}m` for regular grids (e.g., `V100m` for EGMS L3) or `V{value}-{value}m` for irregular grids (e.g., `V20-5m` for EGMS L2 point data)
 
-Only `R` and `V` exist — there is no separate point-grid prefix.
+Only `R` and `V` exist - there is no separate point-grid prefix.
 
 **Compliant:** `R10m`, `R1km`, `R100m`, `R20-5m`, `V025ha`, `V25ha`, `V100m`, `V20-5m`
 
@@ -182,9 +182,9 @@ Only `R` and `V` exist — there is no separate point-grid prefix.
 
 ---
 
-## Principle 10 — Spatial Extent: Identifies the area covered by this specific file
+## Principle 10 - Spatial Extent: Identifies the area covered by this specific file
 
-**Rule:** This field identifies the spatial extent of the individual file — not the overall product coverage. It can be a grid tile, a satellite scene, an administrative boundary, or a continental code:
+**Rule:** This field identifies the spatial extent of the individual file - not the overall product coverage. It can be a grid tile, a satellite scene, an administrative boundary, or a continental code:
 
 | Extent type   | Description                                        | Examples                                   |
 |---------------|----------------------------------------------------|--------------------------------------------|
@@ -200,7 +200,7 @@ Only `R` and `V` exist — there is no separate point-grid prefix.
 
 Spatial extent identifiers are `_`-separated from adjacent tokens. Never fuse them with EPSG or resolution.
 
-> **Note:** This field describes the extent of the **file**, not the product. A pan-European product may be delivered as individual MGRS tiles, each with a different spatial extent. Likewise, `EUROPE` means this specific file covers the entire continent — it does not mean the product is "pan-European" by design.
+> **Note:** This field describes the extent of the **file**, not the product. A pan-European product may be delivered as individual MGRS tiles, each with a different spatial extent. Likewise, `EUROPE` means this specific file covers the entire continent - it does not mean the product is "pan-European" by design.
 
 **Compliant:**
 
@@ -214,23 +214,23 @@ Spatial extent identifiers are `_`-separated from adjacent tokens. Never fuse th
 
 ---
 
-## Principle 11 — EPSG Code: Bare code, required for projected CRS, omit when CRS is implicit
+## Principle 11 - EPSG Code: Bare code, required for projected CRS, omit when CRS is implicit
 
 **Rule:** Standalone `_`-separated token containing the bare EPSG code with **no zero-padding** (`3035`). Required for products with a projected CRS (e.g., LAEA 100km extents). Omit when the CRS is implicit in the spatial extent system (e.g., MGRS tiles imply UTM, so EPSG is redundant). Also omit for CRS-independent files (metadata XML, archive containers).
 
-**Rationale:** The bare code is the EPSG identifier exactly as registered (https://epsg.org) — `3035`, `4326`, `32633` — so the token matches the authority and needs no transformation for lookups. EPSG codes are 4–5 digits; the field is bounded, and the surrounding fixed field order keeps parsing deterministic without artificial padding.
+**Rationale:** The bare code is the EPSG identifier exactly as registered (https://epsg.org) - `3035`, `4326`, `32633` - so the token matches the authority and needs no transformation for lookups. EPSG codes are 4–5 digits; the field is bounded, and the surrounding fixed field order keeps parsing deterministic without artificial padding.
 
 **Compliant:**
 
 - `CLMS_VLCC-GRA_S2021_R10m_E27N48_3035_V01-R00.tif` (LAEA tile, EPSG 3035 required)
 - `CLMS_CLCPLUS-LCU_S2023_R10m_E48N37_3035_V01-R00.tif`
-- `CLMS_VPP2-ST-PPI_A20240101P10D_R10m_T33UVS_V01-R00.tif` (MGRS tile — EPSG omitted, CRS implicit)
+- `CLMS_VPP2-ST-PPI_A20240101P10D_R10m_T33UVS_V01-R00.tif` (MGRS tile - EPSG omitted, CRS implicit)
 
 **Non-compliant:** `03035` (zero-padded), `EPSG3035` (prefixed)
 
 ---
 
-## Principle 12 — Version: `V{XX}-R{YY}` single hyphenated field
+## Principle 12 - Version: `V{XX}-R{YY}` single hyphenated field
 
 **Rule:** A single compound token: `V{XX}` (major, 2-digit zero-padded), hyphen, `R{YY}` (revision, 2-digit zero-padded). Never use packed `V{XXX}`.
 
@@ -238,7 +238,7 @@ Spatial extent identifiers are `_`-separated from adjacent tokens. Never fuse th
 
 ---
 
-## Principle 13 — Variable: Hyphenated composite appended to the product code
+## Principle 13 - Variable: Hyphenated composite appended to the product code
 
 **Rule:** The variable identifies the measured or mapped quantity. It is hyphen-appended to the product code at position 2, forming the product identity compound:
 
@@ -249,7 +249,7 @@ Spatial extent identifiers are `_`-separated from adjacent tokens. Never fuse th
 - `PRODUCT_TYPE`: layer type code (`ST`, `VPP`, `GPP`, `SP`, `LCU`)
 - `PARAMETER`: specific measurement (`PPI`, `SOSD`, `TOTAL`, `SCD`)
 - `SEASON`: `S1` or `S2` for multi-seasonal products
-- `QFLAG`: literal suffix for quality flag layers — always last
+- `QFLAG`: literal suffix for quality flag layers - always last
 
 `LCU` (Land Cover / Land Use) is the shared variable for all status and change land cover/use products (UA, CLC, CLCPLUS, RZ, …); status vs change is expressed by the temporal field (`S{YYYY}` vs `C{YYYY}-{YYYY}`), not by the variable.
 
@@ -265,7 +265,7 @@ UA-LCU / CLC-LCU / CLCPLUS-LCU
 
 ---
 
-## Principle 14 — Production Date: Metadata-only unless operationally required
+## Principle 14 - Production Date: Metadata-only unless operationally required
 
 **Rule:** Omit production date from filenames. Include it only when multiple production runs for the same temporal period coexist in the same distribution channel. When present: `{YYYYMMDD}` as the last token before the extension.
 
@@ -273,7 +273,7 @@ UA-LCU / CLC-LCU / CLCPLUS-LCU
 
 ---
 
-## Principle 15 — Sensor Token: Omit unless multi-sensor discrimination is required
+## Principle 15 - Sensor Token: Omit unless multi-sensor discrimination is required
 
 **Rule:** No standalone sensor token in the filename. The sensor is implicit in the product code. Include a sensor token only when the product supports multiple sensor sources distinguishable at file level (e.g., SAR platform identity `_S1B_`).
 
@@ -284,15 +284,15 @@ UA-LCU / CLC-LCU / CLCPLUS-LCU
 
 ---
 
-## Principle 16 — Quality Layers: Separate file, hierarchical `-QFLAG` suffix
+## Principle 16 - Quality Layers: Separate file, hierarchical `-QFLAG` suffix
 
 **Rule:** Quality layers are separate files. Same stem as the data layer, with `-QFLAG` appended to the appropriate hierarchical level of the code-variable compound. No other field may differ between a data file and its quality file.
 
 The `-QFLAG` suffix attaches at the level it applies to:
 
-- `VPP2-VPP-SOSD-QFLAG` — quality applies to the VPP-SOSD product only
-- `VPP2-VPP-QFLAG` — quality applies to all VPP sub-products (SOSD, TOTAL, SEASONAL, etc.)
-- `VPP2-ST-PPI-QFLAG` — quality applies to the PPI measurement only
+- `VPP2-VPP-SOSD-QFLAG` - quality applies to the VPP-SOSD product only
+- `VPP2-VPP-QFLAG` - quality applies to all VPP sub-products (SOSD, TOTAL, SEASONAL, etc.)
+- `VPP2-ST-PPI-QFLAG` - quality applies to the PPI measurement only
 
 **Compliant:**
 
@@ -303,7 +303,7 @@ CLMS_VPP2-ST-PPI-QFLAG_A20240101P10D_R10m_T33UVS_V01-R00.tif ← quality
 
 ---
 
-## Principle 17 — Schema Registration: parsEO schema BEFORE CDSE onboarding
+## Principle 17 - Schema Registration: parsEO schema BEFORE CDSE onboarding
 
 **Rule:** Every new CLMS product must have a registered product code, a parsEO schema with `status: current`, and a naming crosswalk before the first CDSE delivery. The schema defines the filename; CDSE filenames are not reverse-engineered into schemas after the fact.
 
@@ -313,11 +313,11 @@ CLMS_VPP2-ST-PPI-QFLAG_A20240101P10D_R10m_T33UVS_V01-R00.tif ← quality
 
 Some aspects genuinely differ between product families and should not be forced into a single mould:
 
-1. **Raster vs. vector/point-grid resolution** — `R10m` and `V25ha` are different physical quantities; `V` covers both vector MMU (`V{value}ha`) and point grids (`V{value}m`)
-2. **Pan-European vs. local tile encoding** — LAEA grid tiles (`E27N48`) for pan-European products, FUA codes (`DK004L3`) for city-level vector — these are incompatible spatial encodings, both valid
-3. **Annual status vs. scene-level temporal format** — `S{YYYY}` for static maps, `{YYYYMMDD}T{HHMMSS}` for single acquisitions — the right format depends on the product's temporal nature
-4. **Multi-resolution families** — the set of valid resolution values varies per product; each schema enumerates its own
-5. **Production date inclusion** — reflects operational policy; included when corrections under the same version are expected
+1. **Raster vs. vector/point-grid resolution** - `R10m` and `V25ha` are different physical quantities; `V` covers both vector MMU (`V{value}ha`) and point grids (`V{value}m`)
+2. **Pan-European vs. local tile encoding** - LAEA grid tiles (`E27N48`) for pan-European products, FUA codes (`DK004L3`) for city-level vector - these are incompatible spatial encodings, both valid
+3. **Annual status vs. scene-level temporal format** - `S{YYYY}` for static maps, `{YYYYMMDD}T{HHMMSS}` for single acquisitions - the right format depends on the product's temporal nature
+4. **Multi-resolution families** - the set of valid resolution values varies per product; each schema enumerates its own
+5. **Production date inclusion** - reflects operational policy; included when corrections under the same version are expected
 
 ---
 
@@ -333,8 +333,8 @@ Some aspects genuinely differ between product families and should not be forced 
 | 6  | Prefix              | `CLMS_` mandatory for all products, no exceptions                                                                         |
 | 7  | Product code        | Short, uppercase, registered in code registry                                                                             |
 | 8  | Temporal            | `A{start}P{duration}` (aggregated), `S{YYYY}` (status), `C{YYYY}-{YYYY}` (change), `T{start}P{duration}` (timeseries)     |
-| 9  | Resolution          | `R{XX}m` (raster/grid), `V{value}ha` (vector MMU), `V{value}m` (point grid) — hyphen for irregular grids                  |
-| 10 | Spatial extent      | MGRS / LAEA / IW burst / FUA / country / DU / EUROPE — identifies the area of the specific file, not the product coverage |
+| 9  | Resolution          | `R{XX}m` (raster/grid), `V{value}ha` (vector MMU), `V{value}m` (point grid) - hyphen for irregular grids                  |
+| 10 | Spatial extent      | MGRS / LAEA / IW burst / FUA / country / DU / EUROPE - identifies the area of the specific file, not the product coverage |
 | 11 | EPSG                | Bare EPSG code, no zero-padding (`3035`); required for projected CRS, omit when CRS is implicit in the spatial extent     |
 | 12 | Version             | `V{XX}-R{YY}` single hyphenated field; no packed `V{XXX}`                                                                 |
 | 13 | Variable            | `{CODE}-{TYPE}[-{PARAM}][-{SEASON}][-QFLAG]` compound at position 2                                                       |

--- a/DOCS/filenaming/clms-filenaming_filename-tree_v1.qmd
+++ b/DOCS/filenaming/clms-filenaming_filename-tree_v1.qmd
@@ -3,12 +3,12 @@ author: European Environment Agency (EEA)
 category: guidelines
 date: '2026-07-24'
 subtitle: Copernicus Land Monitoring Service - Technical Library
-title: CLMS Filename Tree
+title: CLMS Product Filenaming - Filename Tree
 ---
 
-# CLMS Filename Tree
+# CLMS Product Filenaming - Filename Tree
 
-*A visual navigation of all possible CLMS filename variants. Each level shows the options for that field. All structural variants are shown, but the lists of variables, tiles, dates & values are exemplary — not exhaustive.*
+*A visual navigation of all possible CLMS filename variants. Each level shows the options for that field. All structural variants are shown, but the lists of variables, tiles, dates & values are exemplary - not exhaustive.*
 
 ---
 
@@ -157,8 +157,8 @@ CLMS_
 ├── {PARAM}                        Single token       (VLCC, NVLCC, SLF, HRL)
 │   ├── GRA, DLT, CTY              (VLCC)
 │   ├── IMCCS, SBCC, SFW, CM       (NVLCC, SLF)
-│   ├── TCD, FTY, IMD, IBU, WAW    (HRL — 10m)
-│   └── SWF                         (HRL — 5m)
+│   ├── TCD, FTY, IMD, IBU, WAW    (HRL - 10m)
+│   └── SWF                         (HRL - 5m)
 │
 ├── {SUB}-{PARAM}                  Two-level          (WSI, VPP2)
 │   ├── SP-SCD
@@ -187,14 +187,14 @@ CLMS_
 
 ```
 CLMS_
-     ├── WSI-SP-SCD_                  Water & Snow/Ice — Snow Cover Duration
+     ├── WSI-SP-SCD_                  Water & Snow/Ice - Snow Cover Duration
      │   └── A20240101P1Y_            annual composite
      │       └── R20m_                raster 20m
      │           └── T38TKL_          MGRS tile
      │               └── 3035_        EPSG 3035
      │                   └── V01-R00.tif  version 1, revision 0
      │
-     └── EGMS-L2a-A_                  European Ground Motion — L2a ascending
+     └── EGMS-L2a-A_                  European Ground Motion - L2a ascending
          └── T20190101P5Y_            5-year timeseries
              └── R20-5m_              irregular grid 20x5m
                  └── 054-0154-IW1_    IW burst


### PR DESCRIPTION
Rename both docs to the shared clms-filenaming_<topic>_v1.qmd pattern, align both titles to 'CLMS Product Filenaming - <Topic>', and replace em dashes with plain hyphens throughout.