### PR TITLE
feat: set default document licence to CC BY 4.0

### DIFF
--- a/.github/scripts/build/strip_unknown_frontmatter.py
+++ b/.github/scripts/build/strip_unknown_frontmatter.py
@@ -10,6 +10,7 @@ Allowlist (matches the PR-time validator in validate_qmd_files.py):
   - tool-managed: version (set by ai/update_versions_and_changelogs.py),
     keywords (set by ai/tasks/generate_intros.py), original-filename (set by
     the technical-library scripts)
+  - licence override: license + license-url (defaults in _meta/includes)
 
 Anything else (toc/toc-depth/toc-title, deprecated fields, typos, external-
 project metadata) gets dropped silently.
@@ -40,6 +41,11 @@ ALLOWLIST = {
     # Kept (not stripped) so fill_version / inject_changelog / strip_llms can
     # read it downstream.
     "type",
+    # Per-document licence override. Both are needed: `license` drives Quarto's
+    # HTML appendix, `license-url` the json-ld block. Defaults live in
+    # _meta/includes/default*.yml; the PR-time validator requires the pair.
+    "license",
+    "license-url",
 }
 
 EXCLUDED_DIRS = {"templates", "theme", "includes", "_meta", "_site", ".quarto"}

--- a/.github/scripts/validate_qmd_files.py
+++ b/.github/scripts/validate_qmd_files.py
@@ -129,6 +129,21 @@ def validate_qmd(file_path: Path) -> List[str]:
     if author is not None and not isinstance(author, (str, list)):
         issues.append("author, if present, must be a string or list of strings")
 
+    # `license` feeds Quarto's HTML appendix; `license-url` feeds the json-ld
+    # block, which cannot read `license` back (Quarto consumes it). Setting one
+    # alone silently publishes two different licences, so require the pair.
+    license_v = metadata.get("license")
+    license_url = metadata.get("license-url")
+    if (license_v is None) != (license_url is None):
+        present, missing = (
+            ("license", "license-url")
+            if license_v is not None
+            else ("license-url", "license")
+        )
+        issues.append(
+            f"{present} is set but {missing} is not; override both or neither"
+        )
+
     return issues
 
 

--- a/_meta/includes/default-no-headers.yml
+++ b/_meta/includes/default-no-headers.yml
@@ -5,7 +5,8 @@ toc-depth: 3 # Include headings up to level 3 (###)
 number-sections: true
 sitemap: true # Enables sitemap generation for web crawlers
 tbl-colwidths: auto
-license: "EUPL (>= 1.2)"
+license: "https://creativecommons.org/licenses/by/4.0/"
+license-url: "https://creativecommons.org/licenses/by/4.0/"
 format:
   html:
     include-in-header:

--- a/_meta/includes/default.yml
+++ b/_meta/includes/default.yml
@@ -5,7 +5,7 @@ toc-depth: 3 # Include headings up to level 3 (###)
 number-sections: true
 sitemap: true # Enables sitemap generation for web crawlers
 tbl-colwidths: auto
-license: "EUPL (>= 1.2)"
+license: "https://creativecommons.org/licenses/by/4.0/"
 format:
   html:
     include-in-header:

--- a/_meta/includes/default.yml
+++ b/_meta/includes/default.yml
@@ -6,6 +6,7 @@ number-sections: true
 sitemap: true # Enables sitemap generation for web crawlers
 tbl-colwidths: auto
 license: "https://creativecommons.org/licenses/by/4.0/"
+license-url: "https://creativecommons.org/licenses/by/4.0/"
 format:
   html:
     include-in-header:

--- a/_meta/includes/json-ld.html
+++ b/_meta/includes/json-ld.html
@@ -19,7 +19,7 @@
     },
     "articleSection": "General",
     "isAccessibleForFree": "true",
-    "license": "{{< meta license | default: 'https://creativecommons.org/licenses/by/4.0/' >}}",
+    "license": "{{< meta license-url >}}",
     "speakable": {
       "@type": "SpeakableSpecification",
       "cssSelector": "article p"

--- a/_meta/includes/json-ld.html
+++ b/_meta/includes/json-ld.html
@@ -19,7 +19,7 @@
     },
     "articleSection": "General",
     "isAccessibleForFree": "true",
-    "license": "{{< meta license | default: '' >}}",
+    "license": "{{< meta license | default: 'https://creativecommons.org/licenses/by/4.0/' >}}",
     "speakable": {
       "@type": "SpeakableSpecification",
       "cssSelector": "article p"


### PR DESCRIPTION
Sets the default document licence to CC BY 4.0 (Creative Commons Attribution 4.0 International).

Changes:
- `_meta/includes/default.yml`: `license` default changed from `"EUPL (>= 1.2)"` to `"https://creativecommons.org/licenses/by/4.0/"`
- `_meta/includes/json-ld.html`: template fallback changed from `""` to `"https://creativecommons.org/licenses/by/4.0/"`

This creates a clean override chain: document frontmatter → default.yml → template fallback. Documents needing a different licence (e.g. third-party content, software docs) override `license:` in their YAML header.