### PR TITLE
fix: correct typo SFW in filename tree

### DIFF
--- a/DOCS/filenaming/clms-filenaming_filename-tree_v1.qmd
+++ b/DOCS/filenaming/clms-filenaming_filename-tree_v1.qmd
@@ -39,7 +39,7 @@ CLMS_
 │   └── IMCCS_S{YYYY}_R10m_E{XXX}N{YYY}_3035_V01-R00.tif
 │
 ├── SLF-                           Small Landscape Features
-│   └── SFW_S{YYYY}_R5m_E{XXX}N{YYY}_3035_V01-R01.tif
+│   └── SWF_S{YYYY}_R5m_E{XXX}N{YYY}_3035_V01-R01.tif
 │
 ├── WSI-                           Water & Snow/Ice
 │   ├── SP-SCD_A{YYYYMMDD}P1Y_R20m_T{ZZ}{GZD}{AA}_V01-R00.tif
@@ -156,7 +156,7 @@ CLMS_
 {CODE}-{VARIABLE}_
 ├── {PARAM}                        Single token       (VLCC, NVLCC, SLF, HRL)
 │   ├── GRA, DLT, CTY              (VLCC)
-│   ├── IMCCS, SBCC, SFW, CM       (NVLCC, SLF)
+│   ├── IMCCS, SBCC, SWF, CM       (NVLCC, SLF)
 │   ├── TCD, FTY, IMD, IBU, WAW    (HRL - 10m)
 │   └── SWF                         (HRL - 5m)
 │


### PR DESCRIPTION
Corrects the type label in the CLMS Product Filenaming - Filename Tree document.